### PR TITLE
conform to V1.FLOW module type changes in mirage; change supported ocaml to >= 4.03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
         - TESTS=false
     matrix:
         - OCAML_VERSION=4.03
-        - OCAML_VERSION=4.02
+        - OCAML_VERSION=4.04

--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
 true: bin_annot, safe_string, principal
 true: warn(A-44)
 
-<lib/*>: package(lwt cstruct mirage-types.lwt mirage-runtime)
+<lib/*>: package(lwt cstruct mirage-types.lwt)

--- a/opam
+++ b/opam
@@ -21,7 +21,6 @@ depends: [
   "topkg" {build}
   "mirage-types-lwt"
   "mirage-solo5"
-  "mirage-runtime"
   "cstruct"
   "lwt"
 ]

--- a/opam
+++ b/opam
@@ -24,3 +24,4 @@ depends: [
   "cstruct"
   "lwt"
 ]
+available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
Bonus: remove `mirage-runtime` dependency.