### PR TITLE
write_one: block until all the bytes are written

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
 true: bin_annot, safe_string, principal
 true: warn(A-44)
 
-<src/*>: package(lwt cstruct mirage-console-lwt)
+<src/*>: package(lwt cstruct cstruct-lwt mirage-console-lwt)

--- a/opam
+++ b/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-console-lwt" {>= "2.2.0"}
   "mirage-solo5"
   "cstruct"
+  "cstruct-lwt"
   "lwt"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Console implementation for Solo5"
 version = "%%VERSION_NUM%%"
-requires = "lwt cstruct mirage-solo5 mirage-types-lwt"
+requires = "lwt cstruct cstruct-lwt mirage-solo5 mirage-console-lwt"
 archive(byte) = "mirage-console-solo5.cma"
 archive(native) = "mirage-console-solo5.cmxa"
 plugin(byte) = "mirage-console-solo5.cma"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -4,9 +4,7 @@
 open Topkg
 
 let () =
-  let lint_deps_excluding =
-    Some ["mirage-solo5" ; "mirage-types-lwt" ; "mirage-types" ]
-  in
+  let lint_deps_excluding = Some ["mirage-solo5" ] in
   let opams = [ Pkg.opam_file "opam" ~lint_deps_excluding ] in
   Pkg.describe ~opams "mirage-console-solo5" @@ fun c ->
   Ok [ Pkg.mllib "src/mirage-console-solo5.mllib"; ]

--- a/src/console_solo5.ml
+++ b/src/console_solo5.ml
@@ -17,7 +17,7 @@
 open Lwt.Infix
 open Result
 
-external solo5_console_write: string -> unit = "stub_console_write"
+external solo5_console_write: string -> int = "stub_console_write"
 
 (* TODO everything connects to the same console for now *)
 (* TODO management service for logging *)
@@ -46,8 +46,9 @@ let disconnect _t = Lwt.return_unit
 let read _t = Lwt.return @@ Ok `Eof
 
 let write_one buf =
-  solo5_console_write (Cstruct.to_string buf);
-  Lwt.return_unit
+  Lwt_cstruct.complete (fun buf ->
+      Lwt.return (solo5_console_write (Cstruct.to_string buf)))
+    buf
 
 let write t buf =
   if t.closed then


### PR DESCRIPTION
note: this also cleans up some dependencies:  mirage-types-* is not used here anymore at all.

I'm unsure about this cstruct-lwt in META -- since there seems to be a rename from cstruct-lwt.0 to cstruct-lwt.3.0.0 (the former is a virtual package, and the actual symbol is in cstruct.lwt, the latter is a package for real, and the symbol is available via cstruct-lwt) -- is there a way to handle this properly?  or should we depend on cstruct >= 3.0.0 (which seems a bad idea since there are several packages not yet working with this new cstruct release)  any hints @avsm @samoht ?